### PR TITLE
Fix Qt signal disconnect error

### DIFF
--- a/controllers/cover_controller.py
+++ b/controllers/cover_controller.py
@@ -59,11 +59,10 @@ class CoverController(QObject):
         nb = self.view.content.new_book_button
         # The 'clicked' signal for the main "new_book_button" is special and leads to _create_wordbook
         # Other buttons' 'openRequested' is for opening existing wordbooks.
-        if nb.receivers(nb.clicked) > 0:
-            try:
-                nb.clicked.disconnect()  # Standard QPushButton signal
-            except (RuntimeError, TypeError):
-                pass
+        try:
+            nb.clicked.disconnect()  # Standard QPushButton signal
+        except (RuntimeError, TypeError):
+            pass
         nb.clicked.connect(self._create_wordbook)
         self._wire_button_signals(nb)  # Wire other common signals
 
@@ -92,16 +91,15 @@ class CoverController(QObject):
 
         # ViewModel style connections for rename/delete actions
         if hasattr(btn, 'renameRequested'):
-            if btn.receivers(btn.renameRequested) > 0:
-                try:
-                    btn.renameRequested.disconnect(self._handle_button_rename)
-                except (TypeError, RuntimeError):
-                    pass
+            try:
+                btn.renameRequested.disconnect(self._handle_button_rename)
+            except (TypeError, RuntimeError):
+                pass
             btn.renameRequested.connect(self._handle_button_rename)
 
         if hasattr(btn, 'deleteRequested'):
             handler = getattr(btn, "_del_handler", None)
-            if handler and btn.receivers(btn.deleteRequested) > 0:
+            if handler:
                 try:
                     btn.deleteRequested.disconnect(handler)
                 except (TypeError, RuntimeError):
@@ -112,20 +110,18 @@ class CoverController(QObject):
 
         # For opening regular wordbooks (not folders, not the new_book_button)
         if hasattr(btn, 'openRequested') and not btn.is_folder and not getattr(btn, 'is_new_button', False):
-            if btn.receivers(btn.openRequested) > 0:
-                try:
-                    btn.openRequested.disconnect()
-                except (TypeError, RuntimeError):
-                    pass
+            try:
+                btn.openRequested.disconnect()
+            except (TypeError, RuntimeError):
+                pass
             btn.openRequested.connect(lambda p=btn.path: self._open_wordbook(p) if p else None)
 
         # For saving layout after name change via inline edit
         if hasattr(btn, 'nameChangedNeedsLayoutSave'):
-            if btn.receivers(btn.nameChangedNeedsLayoutSave) > 0:
-                try:
-                    btn.nameChangedNeedsLayoutSave.disconnect(self.save_current_layout)
-                except (TypeError, RuntimeError):
-                    pass
+            try:
+                btn.nameChangedNeedsLayoutSave.disconnect(self.save_current_layout)
+            except (TypeError, RuntimeError):
+                pass
             btn.nameChangedNeedsLayoutSave.connect(self.save_current_layout)
 
     def _handle_button_rename(self, new_name: str):
@@ -161,11 +157,10 @@ class CoverController(QObject):
             # Reconnect openRequested signal if path changed for a wordbook
             if not button_renamed.is_folder and not getattr(button_renamed, 'is_new_button', False) and hasattr(
                     self.view.content, "show_word_book") and button_renamed.path:
-                if button_renamed.receivers(button_renamed.openRequested) > 0:
-                    try:
-                        button_renamed.openRequested.disconnect()
-                    except(RuntimeError, TypeError):
-                        pass
+                try:
+                    button_renamed.openRequested.disconnect()
+                except (RuntimeError, TypeError):
+                    pass
                 button_renamed.openRequested.connect(
                     lambda p=button_renamed.path: self.view.content.show_word_book(p) if p else None)
 
@@ -183,11 +178,10 @@ class CoverController(QObject):
             return
 
     def _wire_context_menu(self, btn: WordBookButton) -> None:
-        if btn.receivers(btn.customContextMenuRequested) > 0:
-            try:
-                btn.customContextMenuRequested.disconnect()
-            except (RuntimeError, TypeError):
-                pass
+        try:
+            btn.customContextMenuRequested.disconnect()
+        except (RuntimeError, TypeError):
+            pass
         btn.setContextMenuPolicy(Qt.CustomContextMenu)
         btn.customContextMenuRequested.connect(
             lambda pos, b=btn: self._show_button_context_menu(pos, b)

--- a/services/folder_service.py
+++ b/services/folder_service.py
@@ -64,11 +64,10 @@ class FolderService:
 
             # 点击 → 打开单词本
             if hasattr(self.content, "show_word_book"):
-                if btn.receivers(btn.clicked) > 0:
-                    try:
-                        btn.clicked.disconnect()
-                    except (RuntimeError, TypeError):
-                        pass
+                try:
+                    btn.clicked.disconnect()
+                except (RuntimeError, TypeError):
+                    pass
                 btn.clicked.connect(lambda _=False, p=btn.path: self.content.show_word_book(p))
 
             buttons.append(btn)


### PR DESCRIPTION
## Summary
- avoid using `QObject.receivers()` with SignalInstance
- connect/disconnect signals with try/except blocks

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_684d3e8a72cc832f8aa308e13d87f946