### PR TITLE
Smooth realtime button reordering

### DIFF
--- a/UI/folder_ui/_animations.py
+++ b/UI/folder_ui/_animations.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import QGraphicsOpacityEffect
 from typing import Dict, List  # Import Dict and List
 
 # Import necessary components from sibling _modules
-from ._background import FolderBackground  # update_folder_background is called by update_button_positions
+from ._background import FolderBackground, update_all_folder_backgrounds  # update_folder_background is called by update_button_positions
 
 
 def create_folder_toggle_animation(folder_button, target_positions: List[QPoint], button_width, button_height,
@@ -161,6 +161,10 @@ class FolderAnimationMixin:
             # If no folders were actually collapsed (e.g., all were already closed),
             # still trigger a layout update to ensure consistency, especially if exiting edit mode.
             QTimer.singleShot(0, self.update_button_positions)
+
+        # Ensure folder background frames are refreshed after collapsing
+        delay = 600 if any_folder_animated else 0
+        QTimer.singleShot(delay, lambda: update_all_folder_backgrounds(self, self.button_width, self.button_height))
 
     def expand_all_folders(self):
         """恢复上一次 `collapse_all_folders` 保存的展开状态。"""

--- a/UI/folder_ui/_background.py
+++ b/UI/folder_ui/_background.py
@@ -16,15 +16,11 @@ def calculate_folder_background_rect(folder_button, sub_buttons, button_width, b
     if not folder_button.is_expanded or not sub_buttons:
         return None
     
-    # 计算包含所有子按钮的矩形区域
-    visible_sub_buttons = [btn for btn in sub_buttons if btn.isVisible()]
-    if not visible_sub_buttons:
-        return None
-        
-    min_x = min([btn.x() for btn in visible_sub_buttons])
-    min_y = min([btn.y() for btn in visible_sub_buttons])
-    max_x = max([btn.x() + button_width for btn in visible_sub_buttons])
-    max_y = max([btn.y() + button_height for btn in visible_sub_buttons])
+    # 计算包含所有子按钮的矩形区域（无论是否当前可见）
+    min_x = min(btn.x() for btn in sub_buttons)
+    min_y = min(btn.y() for btn in sub_buttons)
+    max_x = max(btn.x() + button_width for btn in sub_buttons)
+    max_y = max(btn.y() + button_height for btn in sub_buttons)
     
     # 添加边距
     margin = spacing // 2

--- a/UI/folder_ui/_background.py
+++ b/UI/folder_ui/_background.py
@@ -98,12 +98,12 @@ def update_folder_background(app, folder_button):
 
 def update_all_folder_backgrounds(app, button_width, button_height):
     """更新所有文件夹的背景框"""
-    # 先隐藏所有背景框，确保Z顺序正确
+    # 先降低所有背景框层级，确保它们处于按钮下方
     for btn in app.buttons:
-        if btn.is_folder and hasattr(btn, 'background_frame'):
+        if btn.is_folder and hasattr(btn, "background_frame"):
             btn.background_frame.lower()
-    
-    # 然后更新所有文件夹背景
+
+    # 然后逐个刷新每个文件夹的背景框
     for btn in app.buttons:
         if btn.is_folder:
             update_folder_background(app, btn)

--- a/UI/folder_ui/_layout.py
+++ b/UI/folder_ui/_layout.py
@@ -183,11 +183,9 @@ class FolderLayoutMixin:
         # ---------- 4) 更新文件夹背景框 ----------
         update_all_folder_backgrounds(self, bw, bh)
 
-    def update_button_order(self, dragged_button: 'WordBookButton'):
+    def update_button_order(self, dragged_button: 'WordBookButton', realtime: bool = False):
         if dragged_button.is_sub_button or not hasattr(self, "buttons"):
             return
-
-        other_buttons = [b for b in self.buttons if b is not dragged_button and not getattr(b, 'is_new_button', False)]
 
         all_main_buttons = [b for b in self.buttons if not b.is_sub_button and not getattr(b, 'is_new_button', False)]
 
@@ -195,9 +193,12 @@ class FolderLayoutMixin:
             all_main_buttons, self.button_width, self.button_height,
             self.spacing, self.scroll_content.width(), getattr(self, "top_margin", 40)
         )
-        if not targets: return
+        if not targets:
+            return
 
         dragged_center = dragged_button.pos() + QPoint(self.button_width // 2, self.button_height // 2)
+        original_index = all_main_buttons.index(dragged_button)
+        original_center = targets[original_index] + QPoint(self.button_width // 2, self.button_height // 2)
 
         closest_slot_index = 0
         min_dist = float('inf')
@@ -211,6 +212,13 @@ class FolderLayoutMixin:
             if dist < min_dist:
                 min_dist = dist
                 closest_slot_index = i
+
+        # Only reorder if the dragged button has moved far enough from its original slot
+        threshold_x = (self.button_width + self.spacing) // 2
+        threshold_y = (self.button_height + self.spacing) // 2
+        if (abs(dragged_center.x() - original_center.x()) <= threshold_x and
+                abs(dragged_center.y() - original_center.y()) <= threshold_y):
+            closest_slot_index = original_index
 
         if dragged_button in self.buttons:
             self.buttons.remove(dragged_button)
@@ -232,9 +240,10 @@ class FolderLayoutMixin:
 
         self.buttons = new_main_buttons_order
 
-        self.animate_button_positions(dragged_button)
+        duration = 100 if realtime else 0
+        self.animate_button_positions(dragged_button, duration)
 
-    def animate_button_positions(self, dragged_button: Optional['WordBookButton'] = None):
+    def animate_button_positions(self, dragged_button: Optional['WordBookButton'] = None, duration: int = 100):
         all_main_buttons = [b for b in self.buttons if not b.is_sub_button and not getattr(b, 'is_new_button', False)]
 
         targets = calculate_main_button_positions(
@@ -243,9 +252,20 @@ class FolderLayoutMixin:
             self.scroll_content.width(), getattr(self, "top_margin", 40)
         )
 
-        for i, btn in enumerate(all_main_buttons):
-            if i < len(targets) and btn is not dragged_button and not getattr(btn, "is_dragging", False):
-                btn.move(targets[i])
+        if duration <= 0:
+            for i, btn in enumerate(all_main_buttons):
+                if i < len(targets) and btn is not dragged_button and not getattr(btn, "is_dragging", False):
+                    btn.move(targets[i])
+            update_all_folder_backgrounds(self, self.button_width, self.button_height)
+        else:
+            from ._animations import create_button_position_animation
+            anim_group = QParallelAnimationGroup(self)
+            for i, btn in enumerate(all_main_buttons):
+                if (i < len(targets) and btn is not dragged_button and
+                        not getattr(btn, "is_dragging", False) and btn.pos() != targets[i]):
+                    anim = create_button_position_animation(btn, targets[i], duration=duration)
+                    anim_group.addAnimation(anim)
+            # Start animations after handling new_book_button
 
         current_x = self.spacing
         current_y = self.spacing + getattr(self, "top_margin", 40)
@@ -269,12 +289,19 @@ class FolderLayoutMixin:
                 current_y += bh + sp
                 current_x = sp
 
-            if not getattr(self.new_book_button, "is_dragging", False) and \
-                    self.new_book_button.pos() != QPoint(current_x, current_y):
-                from ._animations import create_button_position_animation
-                anim = create_button_position_animation(self.new_book_button, QPoint(current_x, current_y),
-                                                        duration=100)
-                anim.start()
+            if duration <= 0:
+                if not getattr(self.new_book_button, "is_dragging", False):
+                    self.new_book_button.move(QPoint(current_x, current_y))
+            else:
+                if (not getattr(self.new_book_button, "is_dragging", False) and
+                        self.new_book_button.pos() != QPoint(current_x, current_y)):
+                    anim = create_button_position_animation(self.new_book_button, QPoint(current_x, current_y),
+                                                            duration=duration)
+                    anim_group.addAnimation(anim)
+
+        if duration > 0 and 'anim_group' in locals():
+            anim_group.finished.connect(lambda: update_all_folder_backgrounds(self, self.button_width, self.button_height))
+            anim_group.start()
 
     def finalize_button_order(self):
         all_main_buttons = [b for b in self.buttons if not b.is_sub_button and not getattr(b, 'is_new_button', False)]

--- a/UI/folder_ui/button.py
+++ b/UI/folder_ui/button.py
@@ -265,7 +265,7 @@ class DraggableButton(QPushButton):
         else:
             # 主界面按钮执行原有的靠近检测和排序
             self.app.check_button_proximity(self)
-            self.app.update_button_order(self)
+            self.app.update_button_order(self, realtime=True)
 
     def mouseReleaseEvent(self, event):
         """

--- a/UI/word_book_button/view.py
+++ b/UI/word_book_button/view.py
@@ -82,6 +82,7 @@ class WordBookButtonView(QPushButton):
         self._edit_mode = False
         self._drag_offset: QPoint | None = None
         self._dragging = False
+        self._collapse_invoked = False
         self.rename_source = "edit"
 
         # —— 内联重命名 & 删除按钮 —— #
@@ -140,17 +141,21 @@ class WordBookButtonView(QPushButton):
             if self._edit_mode:
                 self._drag_offset = ev.pos()
                 self._dragging = False
+                self._collapse_invoked = False
                 self.raise_()
                 if (hasattr(self, "app") and self.app and not self.is_sub_button
-                        and hasattr(self.app, "collapse_all_folders")):
+                        and hasattr(self.app, "collapse_all_folders") and not self._collapse_invoked):
                     try:
                         self.app.collapse_all_folders()
+                        self._collapse_invoked = True
                     except Exception:
                         pass
         super().mousePressEvent(ev)
 
     def mouseReleaseEvent(self, ev):  # noqa: N802
         if ev.button() == Qt.LeftButton:
+            collapse_was_invoked = self._collapse_invoked
+            self._collapse_invoked = False
             self._long_press_timer.stop()
             self._fade_dark()
             if self._edit_mode and self._dragging:
@@ -177,6 +182,11 @@ class WordBookButtonView(QPushButton):
                         self.parent().update_button_positions()
                     except Exception:
                         pass
+            elif self._edit_mode and collapse_was_invoked and not self.is_sub_button and hasattr(self.app, 'expand_all_folders'):
+                try:
+                    self.app.expand_all_folders()
+                except Exception:
+                    pass
             elif not self._edit_mode and self.rect().contains(ev.pos()):
                 if self.is_folder and hasattr(self, "app") and self.app:
                     try:
@@ -192,9 +202,10 @@ class WordBookButtonView(QPushButton):
             if not self._dragging and (ev.pos() - self._drag_offset).manhattanLength() > 3:
                 self._dragging = True
                 if (hasattr(self, "app") and self.app and not self.is_sub_button and
-                        hasattr(self.app, "collapse_all_folders")):
+                        hasattr(self.app, "collapse_all_folders") and not self._collapse_invoked):
                     try:
                         self.app.collapse_all_folders()
+                        self._collapse_invoked = True
                     except Exception:
                         pass
             if self._dragging:

--- a/UI/word_book_button/view.py
+++ b/UI/word_book_button/view.py
@@ -141,6 +141,12 @@ class WordBookButtonView(QPushButton):
                 self._drag_offset = ev.pos()
                 self._dragging = False
                 self.raise_()
+                if (hasattr(self, "app") and self.app and not self.is_sub_button
+                        and hasattr(self.app, "collapse_all_folders")):
+                    try:
+                        self.app.collapse_all_folders()
+                    except Exception:
+                        pass
         super().mousePressEvent(ev)
 
     def mouseReleaseEvent(self, ev):  # noqa: N802
@@ -185,6 +191,12 @@ class WordBookButtonView(QPushButton):
         if self._edit_mode and ev.buttons() & Qt.LeftButton and self._drag_offset is not None:
             if not self._dragging and (ev.pos() - self._drag_offset).manhattanLength() > 3:
                 self._dragging = True
+                if (hasattr(self, "app") and self.app and not self.is_sub_button and
+                        hasattr(self.app, "collapse_all_folders")):
+                    try:
+                        self.app.collapse_all_folders()
+                    except Exception:
+                        pass
             if self._dragging:
                 new_pos = self.mapToParent(ev.pos() - self._drag_offset)
                 self.move(new_pos)
@@ -206,7 +218,7 @@ class WordBookButtonView(QPushButton):
                             self.drag_out_threshold_exceeded = True
                     else:
                         self.app.check_button_proximity(self)
-                        self.app.update_button_order(self)
+                        self.app.update_button_order(self, realtime=True)
                 return
         super().mouseMoveEvent(ev)
 

--- a/WordBookButton.py
+++ b/WordBookButton.py
@@ -501,6 +501,7 @@ class WordBookButton(QPushButton):
         self._end_press_effect()
 
         was_dragging_in_edit_mode = self.is_dragging  # is_dragging is now only true if threshold met
+        collapse_was_invoked = self._collapse_invoked
 
         # Reset dragging state and press position for next interaction
         self.is_dragging = False
@@ -540,6 +541,9 @@ class WordBookButton(QPushButton):
             # QPushButton's default mouseReleaseEvent implementation handles emitting 'clicked()'
             # if the release is within bounds.
             else:
+                if collapse_was_invoked and not self.is_sub_button and hasattr(self.app, 'expand_all_folders'):
+                    self.app.expand_all_folders()
+
                 # If it's a "new button", let the controller handle its specific click.
                 # For other buttons, the controller also connects the `clicked` signal.
                 # So, allowing super.mouseReleaseEvent() should be correct for all click types.

--- a/WordBookButton.py
+++ b/WordBookButton.py
@@ -34,6 +34,7 @@ class WordBookButton(QPushButton):
         self._cursor_offset = QPoint()
         self.drag_out_threshold_exceeded = False
         self._origin_pos = QPoint()  # Original widget position before drag
+        self._collapse_invoked = False  # Track whether collapse_all_folders has run for this drag
 
         self._rotation = 0.0
         if hasattr(self.app, "button_width") and hasattr(self.app, "button_height"):
@@ -381,11 +382,44 @@ class WordBookButton(QPushButton):
         self.delete_button.setVisible(show)
         if show: self.delete_button.raise_()
 
+    def _collapse_all_folders_with_recenter(self):
+        if (self._collapse_invoked or self.is_sub_button or not self.app or
+                not hasattr(self.app, 'collapse_all_folders')):
+            return
+        self._collapse_invoked = True
+        scroll_area = getattr(self.app, "scroll_area", None)
+        old_scroll_value = scroll_area.verticalScrollBar().value() if scroll_area else 0
+        self.app.collapse_all_folders()
+
+        def _reposition_after_collapse():
+            if not self.is_dragging and self.mouse_press_pos_local is None:
+                self._stop_recenter_timer()
+                return
+            if not self.parentWidget():
+                self._stop_recenter_timer()
+                return
+            if scroll_area:
+                current_max_scroll = scroll_area.verticalScrollBar().maximum()
+                scroll_area.verticalScrollBar().setValue(min(old_scroll_value, current_max_scroll))
+            current_mouse_global = QCursor.pos()
+            target_button_global_tl = current_mouse_global - self._cursor_offset
+            new_local_pos = self.parentWidget().mapFromGlobal(target_button_global_tl)
+            if (self.pos() - new_local_pos).manhattanLength() > 1:
+                self.move(new_local_pos)
+
+        self._recenter_timer = QTimer(self)
+        self._recenter_timer.setInterval(10)
+        self._recenter_timer.timeout.connect(_reposition_after_collapse)
+        self._recenter_timer.start()
+        _reposition_after_collapse()
+        QTimer.singleShot(800, self._stop_recenter_timer)
+
     def mousePressEvent(self, event):
         if event.button() == Qt.LeftButton:
             self._start_press_effect()
             self.mouse_press_pos_local = event.position().toPoint()  # Store local press position
             self.is_dragging = False  # Assume it's a click until drag threshold is met
+            self._collapse_invoked = False  # reset for new press
 
             if self.app and self.app.edit_mode and not getattr(self, "is_new_button", False):
                 self._origin_pos = self.pos()
@@ -395,37 +429,8 @@ class WordBookButton(QPushButton):
                 self.raise_()  # Raise button for dragging
 
                 # Recenter timer logic only if it's a main button and collapse is needed
-                if not self.is_sub_button and hasattr(self.app, 'collapse_all_folders'):
-                    scroll_area = getattr(self.app, "scroll_area", None)
-                    old_scroll_value = scroll_area.verticalScrollBar().value() if scroll_area else 0
-                    self.app.collapse_all_folders()
-
-                    def _reposition_after_collapse():
-                        # Check if still valid to reposition (e.g., button still exists, drag ongoing)
-                        if not self.is_dragging and self.mouse_press_pos_local is None:  # Check if drag started
-                            self._stop_recenter_timer()
-                            return
-                        if not self.parentWidget():  # Safety check
-                            self._stop_recenter_timer()
-                            return
-
-                        if scroll_area:
-                            current_max_scroll = scroll_area.verticalScrollBar().maximum()
-                            scroll_area.verticalScrollBar().setValue(min(old_scroll_value, current_max_scroll))
-
-                        current_mouse_global = QCursor.pos()
-                        target_button_global_tl = current_mouse_global - self._cursor_offset
-                        new_local_pos = self.parentWidget().mapFromGlobal(target_button_global_tl)
-
-                        if (self.pos() - new_local_pos).manhattanLength() > 1:
-                            self.move(new_local_pos)
-
-                    self._recenter_timer = QTimer(self)
-                    self._recenter_timer.setInterval(10)
-                    self._recenter_timer.timeout.connect(_reposition_after_collapse)
-                    self._recenter_timer.start()
-                    _reposition_after_collapse()  # Try immediate reposition
-                    QTimer.singleShot(800, self._stop_recenter_timer)  # Safety stop
+                if not self.is_sub_button:
+                    self._collapse_all_folders_with_recenter()
             # For non-edit mode, or "new button", we still call super.mousePressEvent
             # to get the visual "pressed" state. The actual "clicked" signal is emitted on release.
             else:
@@ -447,8 +452,12 @@ class WordBookButton(QPushButton):
         if not self.is_dragging and self.mouse_press_pos_local is not None:
             if (event.position().toPoint() - self.mouse_press_pos_local).manhattanLength() > self.DRAG_THRESHOLD:
                 self.is_dragging = True
-                # Potentially stop recenter timer here if it was started, as manual drag takes over
-                self._stop_recenter_timer()
+                # If collapse wasn't invoked on press (e.g. edit_mode toggled after press), do it now
+                if not self._collapse_invoked:
+                    self._collapse_all_folders_with_recenter()
+                # Stop recenter timer once dragging begins
+                else:
+                    self._stop_recenter_timer()
 
         if not self.is_dragging:
             # If not dragging yet (threshold not met), let super handle it
@@ -485,7 +494,7 @@ class WordBookButton(QPushButton):
                 self.drag_out_threshold_exceeded = True
         else:  # Main button drag
             self.app.check_button_proximity(self)
-            self.app.update_button_order(self)  # This calls animate_button_positions
+            self.app.update_button_order(self, realtime=True)
 
     def mouseReleaseEvent(self, event):
         self._stop_recenter_timer()
@@ -495,6 +504,7 @@ class WordBookButton(QPushButton):
 
         # Reset dragging state and press position for next interaction
         self.is_dragging = False
+        self._collapse_invoked = False
         current_mouse_press_pos_local = self.mouse_press_pos_local
         self.mouse_press_pos_local = None
 

--- a/controllers/cover_controller.py
+++ b/controllers/cover_controller.py
@@ -6,6 +6,8 @@ from PySide6.QtCore import QObject, QEvent, Slot, Qt, QUrl, QTimer
 from PySide6.QtWidgets import QMenu, QMessageBox
 from PySide6.QtGui import QDesktopServices
 
+from UI.folder_ui.api import update_all_folder_backgrounds
+
 from UI.word_book_cover.cover_view import CoverView
 from services.folder_service import FolderService
 from services.cover_layout_service import CoverLayoutService
@@ -388,11 +390,14 @@ class CoverController(QObject):
                     QTimer.singleShot(50, lambda b_folder=btn: [sub.start_jitter() for sub in b_folder.sub_buttons if
                                                                 b_folder.is_expanded])
 
-            # After triggering all folder expansions, force a layout refresh so every
-            # folder gets a correctly sized gray background frame (the first folder
-            # occasionally missed this without an explicit post-expand update).
+            # After triggering all folder expansions, refresh gray background frames
+            # once animations settle so every folder, including the first, displays
+            # its overlay correctly.
             if hasattr(self.view, "content"):
-                QTimer.singleShot(700, self.view.content.update_button_positions)
+                content = self.view.content
+                QTimer.singleShot(700, lambda: update_all_folder_backgrounds(
+                    content, content.button_width, content.button_height
+                ))
 
         else:  # Exiting edit mode
             if hasattr(self.view.content, 'collapse_all_folders'):

--- a/controllers/cover_controller.py
+++ b/controllers/cover_controller.py
@@ -388,6 +388,12 @@ class CoverController(QObject):
                     QTimer.singleShot(50, lambda b_folder=btn: [sub.start_jitter() for sub in b_folder.sub_buttons if
                                                                 b_folder.is_expanded])
 
+            # After triggering all folder expansions, force a layout refresh so every
+            # folder gets a correctly sized gray background frame (the first folder
+            # occasionally missed this without an explicit post-expand update).
+            if hasattr(self.view, "content"):
+                QTimer.singleShot(700, self.view.content.update_button_positions)
+
         else:  # Exiting edit mode
             if hasattr(self.view.content, 'collapse_all_folders'):
                 self.view.content.collapse_all_folders()  # This will animate


### PR DESCRIPTION
## Summary
- collapse folders and recenter buttons when drag starts even if edit mode activates after press
- trigger folder collapse at drag start in `WordBookButtonView`
- refresh gray folder backgrounds after collapsing all folders

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a980e2cb50832f8dc97727521aa832